### PR TITLE
Add NDAR directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # data specific files
 derivatives/*
 sourcedata/
+data-monitoring/ndar/


### PR DESCRIPTION
Ignore NDAR directory by default in new dataset repositories